### PR TITLE
composite pattern error fixes

### DIFF
--- a/src/Composite/Conceptual/index.ts
+++ b/src/Composite/Conceptual/index.ts
@@ -18,7 +18,7 @@
  * для сложных объектов структуры.
  */
 abstract class Component {
-    protected parent: Component;
+    protected parent!: Component | null;
 
     /**
      * EN: Optionally, the base Component can declare an interface for setting
@@ -30,11 +30,11 @@ abstract class Component {
      * также может предоставить некоторую реализацию по умолчанию для этих
      * методов.
      */
-    public setParent(parent: Component) {
+    public setParent(parent: Component | null) {
         this.parent = parent;
     }
 
-    public getParent(): Component {
+    public getParent(): Component | null {
         return this.parent;
     }
 


### PR DESCRIPTION
In composite pattern, when a node (Component) is to be removed, parent property of that component becomes  **null**. In that case, in Component class parent property can have 2 types: when Component is set it becomes typeof **Component**, when Component is removed it becomes **nulll**. I have changed the logic as this. Also because we don't initialize the value on Component class declaration, we basically set the value on run-time we need to use null assertion operator. Typescript compiler/transpiler gives these errors on playground. I have changed the code, errors cleared. You can check it on.
Hope you the best.