### PR TITLE
add return type on createDBConnection of MongoConnectionFactory

### DIFF
--- a/src/FactoryMethod/RealWorld/index.ts
+++ b/src/FactoryMethod/RealWorld/index.ts
@@ -19,7 +19,7 @@ export abstract class DBConnectionFactory {
  * EN: Concrete factories, each of them produces a concrete connection
  */
 export class MongoConnectionFactory extends DBConnectionFactory {
-    public createDBConnection() {
+    public createDBConnection(): DBConnection {
         return new MongoConnection();
     }
 }


### PR DESCRIPTION
Just a tiny change to keep the signatures of createDBConnection consistent