### PR TITLE
Fix: remove duplicate word in Abstract Factory TS example

### DIFF
--- a/src/AbstractFactory/Conceptual/index.ts
+++ b/src/AbstractFactory/Conceptual/index.ts
@@ -95,7 +95,7 @@ class ConcreteProductA2 implements AbstractProductA {
 }
 
 /**
- * EN: Here's the the base interface of another product. All products can
+ * EN: Here's the base interface of another product. All products can
  * interact with each other, but proper interaction is possible only between
  * products of the same concrete variant.
  *


### PR DESCRIPTION
There is a small typo in the Abstract Factory TypeScript example:

"the the base interface" → "the base interface"

This PR removes the duplicated word.